### PR TITLE
Drop req.url.path which hapi no longer needs. Improves #89.

### DIFF
--- a/lib/req.js
+++ b/lib/req.js
@@ -73,12 +73,10 @@ function reqSerializer (req) {
     _req.url = req.originalUrl
     _req.query = req.query
     _req.params = req.params
-  } else if (req.path) {
-    // req.path is to make hapi safe with invalid paths.  req.path() is for restify compat.
-    _req.url = typeof req.path === 'function' ? req.path() : req.path
   } else {
-    // req.url.path is  for hapi compat.
-    _req.url = req.url ? (req.url.path || req.url) : undefined
+    const path = req.path
+    // path for safe hapi compat.
+    _req.url = typeof path === 'string' ? path : (req.url.path || req.url)
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/lib/req.js
+++ b/lib/req.js
@@ -73,9 +73,12 @@ function reqSerializer (req) {
     _req.url = req.originalUrl
     _req.query = req.query
     _req.params = req.params
+  } else if (req.path) {
+    // req.path is to make hapi safe with invalid paths.  req.path() is for restify compat.
+    _req.url = typeof req.path === 'function' ? req.path() : req.path
   } else {
     // req.url.path is  for hapi compat.
-    _req.url = req.path || (req.url ? (req.url.path || req.url) : undefined)
+    _req.url = req.url ? (req.url.path || req.url) : undefined
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/lib/req.js
+++ b/lib/req.js
@@ -76,7 +76,7 @@ function reqSerializer (req) {
   } else {
     const path = req.path
     // path for safe hapi compat.
-    _req.url = typeof path === 'string' ? path : (req.url.path || req.url)
+    _req.url = typeof path === 'string' ? path : req.url
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -252,7 +252,7 @@ test('req.url will be obtained from input request originalUrl when available', f
   }
 })
 
-test('req.url will be obtained from input request path() when a function', function (t) {
+test('req.url will be obtained from input request url when req path is a function', function (t) {
   t.plan(1)
 
   const server = http.createServer(handler)
@@ -265,8 +265,9 @@ test('req.url will be obtained from input request path() when a function', funct
 
   function handler (req, res) {
     req.path = function () {
-      return '/test'
+      throw new Error('unexpected invocation')
     }
+    req.url = '/test'
     const serialized = serializers.reqSerializer(req)
     t.equal(serialized.url, '/test')
     res.end()

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -252,6 +252,27 @@ test('req.url will be obtained from input request originalUrl when available', f
   }
 })
 
+test('req.url will be obtained from input request path() when a function', function (t) {
+  t.plan(1)
+
+  const server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.teardown(() => server.close())
+
+  function handler (req, res) {
+    req.path = function () {
+      return '/test'
+    }
+    const serialized = serializers.reqSerializer(req)
+    t.equal(serialized.url, '/test')
+    res.end()
+  }
+})
+
 test('can wrap request serializers', function (t) {
   t.plan(3)
 

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -177,25 +177,6 @@ test('req.url will be obtained from input request req.path when input request ur
   }
 })
 
-test('req.url will be obtained from input request url.path when input request url is an object', function (t) {
-  t.plan(1)
-
-  const server = http.createServer(handler)
-  server.unref()
-  server.listen(0, () => {
-    http.get(server.address(), () => {})
-  })
-
-  t.teardown(() => server.close())
-
-  function handler (req, res) {
-    req.url = { path: '/test' }
-    const serialized = serializers.reqSerializer(req)
-    t.equal(serialized.url, '/test')
-    res.end()
-  }
-})
-
 test('req.url will be obtained from input request url when input request url is not an object', function (t) {
   t.plan(1)
 
@@ -270,6 +251,25 @@ test('req.url will be obtained from input request url when req path is a functio
     req.url = '/test'
     const serialized = serializers.reqSerializer(req)
     t.equal(serialized.url, '/test')
+    res.end()
+  }
+})
+
+test('req.url being undefined does not throw an error', function (t) {
+  t.plan(1)
+
+  const server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.teardown(() => server.close())
+
+  function handler (req, res) {
+    req.url = undefined
+    const serialized = serializers.reqSerializer(req)
+    t.equal(serialized.url, undefined)
     res.end()
   }
 })


### PR DESCRIPTION
Hapi used to rely on using `req.url.path` but as of #29 it was found to throw in some cases & hapi support now uses `req.path` instead. We can remove the old `req.url.path` if we feel comfortable doing so.

It's possible someone else somewhere may depend on this. But it would be nice to make this somewhat busy part of the code-base cleaner, if we dare.