### PR TITLE
guard against req.url being falsy

### DIFF
--- a/lib/req.js
+++ b/lib/req.js
@@ -76,7 +76,7 @@ function reqSerializer (req) {
   } else {
     const path = req.path
     // path for safe hapi compat.
-    _req.url = typeof path === 'string' ? path : (req.url.path || req.url)
+    _req.url = typeof path === 'string' ? path : req.url
   }
   _req.headers = req.headers
   _req.remoteAddress = connection && connection.remoteAddress

--- a/test/req.test.js
+++ b/test/req.test.js
@@ -177,25 +177,6 @@ test('req.url will be obtained from input request req.path when input request ur
   }
 })
 
-test('req.url will be obtained from input request url.path when input request url is an object', function (t) {
-  t.plan(1)
-
-  const server = http.createServer(handler)
-  server.unref()
-  server.listen(0, () => {
-    http.get(server.address(), () => {})
-  })
-
-  t.teardown(() => server.close())
-
-  function handler (req, res) {
-    req.url = { path: '/test' }
-    const serialized = serializers.reqSerializer(req)
-    t.equal(serialized.url, '/test')
-    res.end()
-  }
-})
-
 test('req.url will be obtained from input request url when input request url is not an object', function (t) {
   t.plan(1)
 
@@ -270,6 +251,25 @@ test('req.url will be obtained from input request url when req path is a functio
     req.url = '/test'
     const serialized = serializers.reqSerializer(req)
     t.equal(serialized.url, '/test')
+    res.end()
+  }
+})
+
+test('req.url being undefined does not throw an error', function (t) {
+  t.plan(1)
+
+  const server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+
+  t.teardown(() => server.close())
+
+  function handler (req, res) {
+    req.url = undefined
+    const serialized = serializers.reqSerializer(req)
+    t.equal(serialized.url, undefined)
     res.end()
   }
 })


### PR DESCRIPTION
it's tempting to simply stop looking at `req.url.path` altogether, since that was introduced for `hapi` 17 in https://github.com/pinojs/pino-std-serializers/commit/83d58a7fbf9cdbeb65bf3c67d269e8c47a02947e#diff-2c4782cb20f7f0d7ca90c7bc04939f4420c4bdb42fdce618984da393ba9202f7R60 .

but since #29 we look at `req.path` first (which has been around since hapi [v1.0.0](https://github.com/hapijs/hapi/blob/v1.0.0/lib/request.js#L128)), which is safer in hapi, so hapi doesn't care about `req.url.path` anymore. this pr presents the 'what if' we drop `req.url.path`.

perhaps someone else does depend on `req.url.path`. but probably no one does. `req.url` is in most cases straight from node's [`message.url`](https://nodejs.org/api/http.html#messageurl), so it's quite traditional to find it, as a string, safe to use. this pr would simplify the `pino-std-serializer` codebase, at some small risk to strange users (but not hapi ones).